### PR TITLE
Fix behaviour of Get-Team with fuzzy results

### DIFF
--- a/M365-Teams-PrüfungsTeams/02-AddStudentsToChannels.ps1
+++ b/M365-Teams-PrüfungsTeams/02-AddStudentsToChannels.ps1
@@ -54,7 +54,7 @@ Connect-MicrosoftTeams | Out-Null
 #
 # Füge SchülerInnen als Member zu jedem Kanal hinzu
 #
-$GroupId = Get-Team -DisplayName $Name.Trim()
+$GroupId = Get-Team -DisplayName $Name.Trim() | Where-Object Displayname -eq $Name.Trim()
 
 Get-TeamChannel -GroupId $GroupId.GroupId -MembershipType Private | ForEach-Object {
     $TeamChannel = $_

--- a/M365-Teams-PrüfungsTeams/03-RemoveStudentsFromChannels.ps1
+++ b/M365-Teams-PrüfungsTeams/03-RemoveStudentsFromChannels.ps1
@@ -54,7 +54,7 @@ Connect-MicrosoftTeams | Out-Null
 #
 # Entferne SchülerInnen aus den Kanälen
 #
-$GroupId = Get-Team -DisplayName $Name.Trim()
+$GroupId = Get-Team -DisplayName $Name.Trim() | Where-Object Displayname -eq $Name.Trim()
 
 Get-TeamChannel -GroupId $GroupId.GroupId -MembershipType Private | ForEach-Object {
     $TeamChannel = $_

--- a/M365-Teams-PrüfungsTeams/04-ArchiveTeam.ps1
+++ b/M365-Teams-PrüfungsTeams/04-ArchiveTeam.ps1
@@ -47,7 +47,7 @@ Connect-MicrosoftTeams | Out-Null
 #
 # Archiviere Team
 #
-$GroupId = Get-Team -DisplayName $Name.Trim()
+$GroupId = Get-Team -DisplayName $Name.Trim() | Where-Object Displayname -eq $Name.Trim()
 
 Write-Host ""
 Write-Host " - Archiviere das Team: " -NoNewline


### PR DESCRIPTION
This pull request primarily focuses on refining the way we fetch a specific team in three different PowerShell scripts. The scripts `02-AddStudentsToChannels.ps1`, `03-RemoveStudentsFromChannels.ps1`, and `04-ArchiveTeam.ps1` are updated to ensure that the `Get-Team` cmdlet fetches the correct team by matching the display name exactly. 

Here are the key changes:

* [`M365-Teams-PrüfungsTeams/02-AddStudentsToChannels.ps1`](diffhunk://#diff-dcccc7fa60ea2308dbd3339b784fff35e3b9fc03f14d7b539c4117660e6cf095L57-R57): Updated the `$GroupId` assignment to fetch the team with an exact match of the display name. This ensures that the correct team is selected when adding students to channels.
* [`M365-Teams-PrüfungsTeams/03-RemoveStudentsFromChannels.ps1`](diffhunk://#diff-24fa39ad9eb5870d35917557a30267c8f6b8bc9351504e0633131aed8df03ab9L57-R57): Similar to the previous change, the `$GroupId` assignment is updated to fetch the team with an exact match of the display name. This ensures that the correct team is selected when removing students from channels.
* [`M365-Teams-PrüfungsTeams/04-ArchiveTeam.ps1`](diffhunk://#diff-bc4819cfa129aacede957e4d441328612e3c31a6d73912783a77380003ed14fcL50-R50): The `$GroupId` assignment is updated to fetch the team with an exact match of the display name. This ensures that the correct team is selected when archiving a team.